### PR TITLE
Reactor client

### DIFF
--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ contains(inputs.runs_on, 'macos') }}
         run: |
           echo "HYPOTHESIS_MAX_EXAMPLES=50" >> $GITHUB_ENV
-      - name: install python dependencies 
+      - name: install python dependencies
         run: pip install pytest hypothesis pytest-xdist
       - name: build (dev)
         run: ${{ inputs.cc_prefix }} make dev
@@ -34,15 +34,15 @@ jobs:
         run: ${{ inputs.cc_prefix }} make release
       - name: test (release)
         run: ${{ inputs.valgrind_prefix }} make check
-      # - name: build with ASan (release)
-      #   run: |
-      #       export CFLAGS="$CFLAGS -O2 -Wall -Wextra -gdwarf-4 -fsanitize=address -fno-omit-frame-pointer"
-      #       ${{ inputs.cc_prefix }} make release
-      # - name: test with ASan (release)
-      #   run: make check
+      - name: build with UBSan (dev)
+        run: |
+          export CFLAGS="$CFLAGS -O0 -g3 -gdwarf-4 -fsanitize=undefined -fno-omit-frame-pointer"
+          ${{ inputs.cc_prefix }} make dev
+      - name: test with UBSan (dev)
+        run: UBSAN_OPTIONS=print_stacktrace=1 make check
       - name: build with UBSan (release)
         run: |
-            export CFLAGS="$CFLAGS -O2 -Wall -Wextra -gdwarf-4 -fsanitize=undefined -fno-omit-frame-pointer"
-            ${{ inputs.cc_prefix }} make release
+          export CFLAGS="$CFLAGS -O3 -DNDEBUG -g0 -fsanitize=undefined -fno-omit-frame-pointer"
+          ${{ inputs.cc_prefix }} make release
       - name: test with UBSan (release)
-        run: make check
+        run: UBSAN_OPTIONS=print_stacktrace=1 make check

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Run modes:
         -m, --multi              multithreaded mode
         -g, --gen                generator mode
         -c, --client             synchronous client mode
-        -L, --load-clients uint  spawn N load clients
         -S, --server             synchronous server mode
         -v, --async-client       asynchronous client mode
         -w, --async-server       asynchronous server mode
         -R, --reactor-server     reactor server mode
+        -L, --load-clients uint  spawn N load clients
 
 Brute modes:
         -i, --iter               iterative bruteforce

--- a/src/load_client.c
+++ b/src/load_client.c
@@ -1,0 +1,711 @@
+#include "load_client.h"
+#include "priority_queue.h"
+
+#include "client_common.h"
+#include "common.h"
+#include "log.h"
+#include "queue.h"
+#include "reactor_common.h"
+#include "thread_pool.h"
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <event2/event.h>
+#include <event2/thread.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MS_IN_SEC (1000L)
+#define USEC_IN_MSEC (1000L)
+#define USEC_IN_SEC (1000000L)
+
+#define MIN_DELAY_USEC (1000)
+#define TASK_TIMEOUT_MS_MIN (100)
+#define TASK_TIMEOUT_MS_MAX (1000)
+#define PENDING_TASKS_QUEUE_CAP (256)
+
+typedef struct spawner_context_t
+{
+  reactor_context_t *rctx;
+  thread_pool_t thread_pool;
+  config_t *config;
+  priority_queue_t pending_tasks;
+  struct event *timer_event;
+  pthread_mutex_t mutex;
+  pthread_cond_t cond_sem;
+  bool done;
+} spawner_context_t;
+
+typedef enum read_stage_t
+{
+  RS_CMD,
+  RS_LEN,
+  RS_DATA,
+} read_stage_t;
+
+typedef struct read_state_t
+{
+  struct iovec vec[1];
+  read_stage_t stage;
+  bool is_partial;
+  command_t cmd;
+  int32_t alph_len;
+} read_state_t;
+
+typedef struct client_context_t
+{
+  client_base_context_t client_base;
+  spawner_context_t *s_ctx;
+  reactor_conn_t rctr_conn;
+  result_t result_buffer;
+  queue_t result_queue;
+  read_state_t read_state;
+  write_state_t write_state;
+  task_t read_buffer;
+  unsigned int rand_seed;
+  bool is_writing;
+  pthread_mutex_t is_writing_mutex;
+} client_context_t;
+
+typedef struct pending_task_t
+{
+  struct timeval deadline;
+  client_context_t *ctx;
+  task_t result;
+} pending_task_t;
+
+static int
+pending_task_cmp (const void *lhs, const void *rhs)
+{
+  const pending_task_t *a = lhs;
+  const pending_task_t *b = rhs;
+  return (evutil_timercmp (&a->deadline, &b->deadline, <)   ? -1
+          : evutil_timercmp (&a->deadline, &b->deadline, >) ? 1
+                                                            : 0);
+}
+
+static void timer_callback (evutil_socket_t fd, short what, void *arg);
+static void client_context_destroy (void *arg);
+static void handle_read (evutil_socket_t socket_fd, short what, void *arg);
+
+static void
+destroy_load_client_if_read_cb (const struct event *ev, void *arg)
+{
+  (void)arg;
+
+  if (event_get_callback (ev) != handle_read)
+    return;
+
+  client_context_t *ctx = event_get_callback_arg (ev);
+  if (!ctx)
+    return;
+
+  trace ("Destroying load client from event snapshot");
+  client_context_destroy (ctx);
+}
+
+static void
+spawner_context_destroy (spawner_context_t *ctx)
+{
+  reactor_context_stop (ctx->rctx);
+
+  if (thread_pool_join (&ctx->thread_pool) == S_FAILURE)
+    error ("Could not join thread pool");
+
+  if (reactor_context_drain_jobs (ctx->rctx) != S_SUCCESS)
+    error ("Could not drain reactor jobs");
+
+  if (ctx->timer_event)
+    {
+      if (event_del (ctx->timer_event) == -1)
+        {
+          /*
+           * The timer may already be non-pending. This is not fatal during
+           * shutdown.
+           */
+        }
+
+      event_free (ctx->timer_event);
+      ctx->timer_event = NULL;
+    }
+
+  priority_queue_destroy (&ctx->pending_tasks);
+
+  if (reactor_for_each_event_snapshot (ctx->rctx,
+                                       destroy_load_client_if_read_cb, NULL)
+      == S_FAILURE)
+    error ("Could not cleanup load clients");
+
+  if (reactor_context_destroy (ctx->rctx) != S_SUCCESS)
+    error ("Could not destroy reactor context");
+
+  pthread_mutex_destroy (&ctx->mutex);
+  pthread_cond_destroy (&ctx->cond_sem);
+}
+
+static status_t
+spawner_context_init (spawner_context_t *ctx, reactor_context_t *rctx,
+                      config_t *config)
+{
+  memset (ctx, 0, sizeof (*ctx));
+
+  ctx->config = config;
+
+  if (thread_pool_init (&ctx->thread_pool) == S_FAILURE)
+    {
+      error ("Could not initialize thread pool");
+      return (S_FAILURE);
+    }
+
+  if (reactor_context_init (rctx) != S_SUCCESS)
+    {
+      error ("Could not initialize reactor context");
+      return (S_FAILURE);
+    }
+  ctx->rctx = rctx;
+
+  if (priority_queue_init (&ctx->pending_tasks, PENDING_TASKS_QUEUE_CAP,
+                           sizeof (pending_task_t), pending_task_cmp)
+      != S_SUCCESS)
+    {
+      error ("Could not initialize pending tasks queue");
+      goto cleanup_reactor;
+    }
+
+  ctx->timer_event
+      = event_new (ctx->rctx->ev_base, -1, EV_TIMEOUT, timer_callback, ctx);
+  if (!ctx->timer_event)
+    {
+      error ("Could not create timer event");
+      goto cleanup_pq;
+    }
+
+  if (pthread_mutex_init (&ctx->mutex, NULL) != 0)
+    {
+      error ("Could not initialize spawner mutex");
+      goto cleanup_timer;
+    }
+
+  if (pthread_cond_init (&ctx->cond_sem, NULL) != 0)
+    {
+      error ("Could not initialize spawner conditional semaphore");
+      pthread_mutex_destroy (&ctx->mutex);
+      goto cleanup_timer;
+    }
+
+  return (S_SUCCESS);
+
+cleanup_timer:
+  event_free (ctx->timer_event);
+  ctx->timer_event = NULL;
+
+cleanup_pq:
+  priority_queue_destroy (&ctx->pending_tasks);
+
+cleanup_reactor:
+  reactor_context_destroy (rctx);
+  return (S_FAILURE);
+}
+
+static status_t
+client_context_init (client_context_t *ctx, spawner_context_t *s_ctx)
+{
+  memset (ctx, 0, sizeof (*ctx));
+
+  ctx->s_ctx = s_ctx;
+  ctx->rctr_conn.fd = -1;
+
+  if (pthread_mutex_init (&ctx->is_writing_mutex, NULL) != 0)
+    {
+      error ("Could not initialize writing mutex");
+      return (S_FAILURE);
+    }
+
+  if (queue_init (&ctx->result_queue, sizeof (result_t)) != QS_SUCCESS)
+    {
+      error ("Could not initialize result queue");
+      pthread_mutex_destroy (&ctx->is_writing_mutex);
+      return (S_FAILURE);
+    }
+
+  ctx->is_writing = false;
+
+  ctx->read_state.stage = RS_CMD;
+  ctx->read_state.is_partial = false;
+  ctx->read_state.alph_len = -1;
+  ctx->read_state.cmd = CMD_HASH;
+
+  ctx->rand_seed = (unsigned)time (NULL) ^ (unsigned)(uintptr_t)ctx;
+
+  if (client_base_context_init (&ctx->client_base, s_ctx->config, NULL)
+      == S_FAILURE)
+    {
+      error ("Could not initialize client base context");
+      queue_destroy (&ctx->result_queue);
+      pthread_mutex_destroy (&ctx->is_writing_mutex);
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+static void
+client_context_destroy (void *arg)
+{
+  client_context_t *ctx = arg;
+
+  if (!ctx)
+    return;
+
+  trace ("Destroying client context");
+
+  /*
+   * reactor_conn_t owns the socket fd once reactor_conn_init() succeeds.
+   * Avoid letting client_base_context_destroy() close the same fd again.
+   */
+  if (reactor_conn_destroy (&ctx->rctr_conn) != S_SUCCESS)
+    error ("Could not destroy reactor connection");
+
+  ctx->client_base.socket_fd = -1;
+
+  if (client_base_context_destroy (&ctx->client_base) != S_SUCCESS)
+    error ("Could not destroy client base context");
+
+  if (pthread_mutex_destroy (&ctx->is_writing_mutex) != 0)
+    error ("Could not destroy writing mutex");
+
+  if (queue_destroy (&ctx->result_queue) != QS_SUCCESS)
+    error ("Could not destroy result queue");
+
+  free (ctx);
+}
+
+static void
+result_write_state_setup (client_context_t *ctx)
+{
+  io_state_t *base_state = &ctx->write_state.base_state;
+  base_state->vec[0].iov_base = &ctx->result_buffer;
+  base_state->vec[0].iov_len = sizeof (ctx->result_buffer);
+  base_state->vec_sz = 1;
+}
+
+static void client_finish (client_context_t *ctx);
+
+static status_t
+send_result_job (void *arg)
+{
+  client_context_t *ctx = arg;
+
+  if (write_state_write (ctx->rctr_conn.fd, &ctx->write_state) != S_SUCCESS)
+    {
+      error ("Could not send result to server");
+      client_finish (ctx);
+      return (S_SUCCESS);
+    }
+
+  if (ctx->write_state.base_state.vec_sz != 0)
+    {
+      reactor_push_status_t ps
+          = reactor_push_job (ctx->s_ctx->rctx, ctx, send_result_job, NULL);
+      return (ps == RPS_FAILURE ? S_FAILURE : S_SUCCESS);
+    }
+
+  trace ("Sent result %s to server", ctx->result_buffer.password);
+
+  queue_status_t qs = queue_trypop (&ctx->result_queue, &ctx->result_buffer);
+  if (qs == QS_EMPTY)
+    {
+      pthread_mutex_lock (&ctx->is_writing_mutex);
+      ctx->is_writing = false;
+      pthread_mutex_unlock (&ctx->is_writing_mutex);
+
+      return (S_SUCCESS);
+    }
+
+  if (qs == QS_FAILURE)
+    {
+      error ("Could not pop from a result queue");
+      return (S_FAILURE);
+    }
+
+  result_write_state_setup (ctx);
+
+  reactor_push_status_t ps
+      = reactor_push_job (ctx->s_ctx->rctx, ctx, send_result_job, NULL);
+
+  return (ps == RPS_FAILURE ? S_FAILURE : S_SUCCESS);
+}
+
+static void
+client_finish (client_context_t *ctx)
+{
+  spawner_context_t *s_ctx = ctx->s_ctx;
+
+  if (pthread_mutex_lock (&s_ctx->mutex) != 0)
+    {
+      error ("Could not lock spawner mutex");
+      return;
+    }
+
+  if (!s_ctx->done)
+    {
+      s_ctx->done = true;
+      if (pthread_cond_signal (&s_ctx->cond_sem) != 0)
+        error ("Could not signal spawner conditional semaphore");
+
+      reactor_context_stop (s_ctx->rctx);
+    }
+
+  if (pthread_mutex_unlock (&s_ctx->mutex) != 0)
+    error ("Could not unlock spawner mutex");
+}
+
+static void
+schedule_timer_for_head (spawner_context_t *spawner_ctx)
+{
+  pending_task_t top;
+  if (priority_queue_top (&spawner_ctx->pending_tasks, &top) != S_SUCCESS)
+    return;
+
+  struct timeval now;
+  evutil_gettimeofday (&now, NULL);
+
+  struct timeval delay;
+  evutil_timersub (&top.deadline, &now, &delay);
+
+  if (delay.tv_sec < 0
+      || (delay.tv_sec == 0 && delay.tv_usec < MIN_DELAY_USEC))
+    {
+      delay.tv_sec = 0;
+      delay.tv_usec = MIN_DELAY_USEC;
+    }
+
+  if (event_del (spawner_ctx->timer_event) == -1)
+    {
+      /*
+       * event_del() may fail if the timer was not pending. This is not fatal
+       * for rescheduling.
+       */
+    }
+
+  if (event_add (spawner_ctx->timer_event, &delay) != 0)
+    error ("Could not add timer");
+
+  trace ("Scheduled timer for priority queue head (%ld.%06ld s)",
+         (long)delay.tv_sec, (long)delay.tv_usec);
+}
+
+static void
+timer_callback (evutil_socket_t fd, short what, void *arg)
+{
+  (void)fd;
+  (void)what;
+
+  spawner_context_t *spawner_ctx = arg;
+
+  if (event_del (spawner_ctx->timer_event) == -1)
+    {
+      /*
+       * The timer callback itself may already be non-pending. Ignore this.
+       */
+    }
+
+  pending_task_t due;
+  if (priority_queue_top (&spawner_ctx->pending_tasks, &due) != S_SUCCESS)
+    return;
+
+  if (priority_queue_pop (&spawner_ctx->pending_tasks) != S_SUCCESS)
+    return;
+
+  result_t *result = &due.result.result;
+  result->is_correct = false;
+
+  pthread_mutex_lock (&due.ctx->is_writing_mutex);
+  bool is_writing = due.ctx->is_writing;
+  due.ctx->is_writing = true;
+  pthread_mutex_unlock (&due.ctx->is_writing_mutex);
+
+  if (is_writing)
+    {
+      if (queue_push_back (&due.ctx->result_queue, result) != QS_SUCCESS)
+        {
+          error ("Could not push result to result queue");
+          client_finish (due.ctx);
+          return;
+        }
+
+      schedule_timer_for_head (spawner_ctx);
+      return;
+    }
+
+  memcpy (&due.ctx->result_buffer, result, sizeof (*result));
+  result_write_state_setup (due.ctx);
+
+  reactor_push_status_t ps = reactor_push_job (due.ctx->s_ctx->rctx, due.ctx,
+                                               send_result_job, NULL);
+
+  if (ps == RPS_FAILURE)
+    {
+      error ("Could not push send result job");
+      client_finish (due.ctx);
+      return;
+    }
+
+  if (ps == RPS_INACTIVE)
+    return;
+
+  trace ("Timer fired: popped pending task, pushed send job");
+
+  schedule_timer_for_head (spawner_ctx);
+}
+
+static status_t
+tryread (client_context_t *ctx, void *base, size_t len)
+{
+  if (!ctx->read_state.is_partial)
+    {
+      ctx->read_state.vec[0].iov_base = base;
+      ctx->read_state.vec[0].iov_len = len;
+    }
+
+  int vec_sz = 1;
+  reactor_io_status_t io_status
+      = reactor_conn_readv (&ctx->rctr_conn, ctx->read_state.vec, &vec_sz);
+
+  if (io_status == RIO_ERROR || io_status == RIO_CLOSED)
+    {
+      client_finish (ctx);
+      return (S_FAILURE);
+    }
+
+  if (io_status == RIO_PENDING)
+    {
+      ctx->read_state.is_partial = true;
+      return (S_FAILURE);
+    }
+
+  ctx->read_state.is_partial = false;
+  return (S_SUCCESS);
+}
+
+static void
+handle_read (evutil_socket_t socket_fd, short what, void *arg)
+{
+  assert (what == EV_READ);
+  (void)socket_fd;
+
+  client_context_t *ctx = arg;
+
+  switch (ctx->read_state.stage)
+    {
+    case RS_CMD:
+      if (tryread (ctx, &ctx->read_state.cmd, sizeof (command_t)) == S_FAILURE)
+        {
+          error ("Could not read command");
+          return;
+        }
+
+      ctx->read_state.stage
+          = ctx->read_state.cmd == CMD_ALPH ? RS_LEN : RS_DATA;
+      break;
+
+    case RS_LEN:
+      if (tryread (ctx, &ctx->read_state.alph_len,
+                   sizeof (ctx->read_state.alph_len))
+          == S_FAILURE)
+        {
+          error ("Could not read alphabet length");
+          return;
+        }
+
+      ctx->read_state.stage = RS_DATA;
+      break;
+
+    case RS_DATA:
+      switch (ctx->read_state.cmd)
+        {
+        case CMD_HASH:
+          if (tryread (ctx, ctx->client_base.hash, HASH_LENGTH) == S_FAILURE)
+            {
+              error ("Could not read hash");
+              return;
+            }
+
+          trace ("Got hash: %s", ctx->client_base.hash);
+          break;
+
+        case CMD_ALPH:
+          if (ctx->read_state.alph_len < 0)
+            {
+              error ("Alphabet length should be greater than 0");
+              goto fail;
+            }
+
+          if (tryread (ctx, ctx->client_base.alph, ctx->read_state.alph_len)
+              == S_FAILURE)
+            {
+              error ("Could not read alphabet");
+              return;
+            }
+
+          ctx->client_base.alph[ctx->read_state.alph_len] = 0;
+          trace ("Got alphabet: %s", ctx->client_base.alph);
+          break;
+
+        case CMD_TASK:
+          if (tryread (ctx, &ctx->read_buffer, sizeof (task_t)) == S_FAILURE)
+            {
+              error ("Could not read task");
+              return;
+            }
+
+          pending_task_t pending = {
+            .ctx = ctx,
+            .result = ctx->read_buffer,
+          };
+
+          result_t *result = &pending.result.result;
+          result->is_correct = false;
+          memset (result->password, 0, sizeof (result->password));
+
+          evutil_gettimeofday (&pending.deadline, NULL);
+
+          long timeout_ms
+              = TASK_TIMEOUT_MS_MIN
+                + (long)(rand_r (&ctx->rand_seed)
+                         % (TASK_TIMEOUT_MS_MAX - TASK_TIMEOUT_MS_MIN + 1));
+
+          pending.deadline.tv_sec += timeout_ms / MS_IN_SEC;
+          pending.deadline.tv_usec += (timeout_ms % MS_IN_SEC) * USEC_IN_MSEC;
+
+          if (pending.deadline.tv_usec >= USEC_IN_SEC)
+            {
+              pending.deadline.tv_sec++;
+              pending.deadline.tv_usec -= USEC_IN_SEC;
+            }
+
+          if (priority_queue_push (&ctx->s_ctx->pending_tasks, &pending)
+              != S_SUCCESS)
+            {
+              error ("Could not push pending task");
+              client_finish (ctx);
+              return;
+            }
+
+          schedule_timer_for_head (ctx->s_ctx);
+          break;
+
+        default:
+          error ("Got unexpected command");
+          goto fail;
+        }
+
+      ctx->read_state.stage = RS_CMD;
+      break;
+    }
+
+  return;
+
+fail:
+  client_finish (ctx);
+}
+
+void *
+spawner_thread (void *arg)
+{
+  spawner_context_t *s_ctx = *(spawner_context_t **)arg;
+
+  for (long i = 0; i < s_ctx->config->number_of_threads; ++i)
+    {
+      client_context_t *ctx = calloc (1, sizeof (*ctx));
+      if (!ctx)
+        return (NULL);
+
+      trace ("Creating load client %ld", i);
+
+      if (client_context_init (ctx, s_ctx) == S_FAILURE)
+        {
+          free (ctx);
+          return (NULL);
+        }
+
+      if (srv_connect (&ctx->client_base) == S_FAILURE)
+        {
+          client_context_destroy (ctx);
+          return (NULL);
+        }
+
+      if (reactor_conn_init (&ctx->rctr_conn, s_ctx->rctx,
+                             ctx->client_base.socket_fd, handle_read, ctx)
+          == S_FAILURE)
+        {
+          error ("Could not initialize reactor connection");
+          client_context_destroy (ctx);
+          return (NULL);
+        }
+
+      if (reactor_conn_enable_read (&ctx->rctr_conn) != S_SUCCESS)
+        {
+          error ("Could not enable reactor read event");
+          client_context_destroy (ctx);
+          return (NULL);
+        }
+    }
+
+  return (NULL);
+}
+
+status_t
+spawn_load_clients (config_t *config)
+{
+  evthread_use_pthreads ();
+
+  spawner_context_t ctx;
+  reactor_context_t rctx;
+  status_t status = S_FAILURE;
+
+  if (spawner_context_init (&ctx, &rctx, config) == S_FAILURE)
+    return (S_FAILURE);
+
+  spawner_context_t *spawner_ptr = &ctx;
+
+  if (!thread_create (&ctx.thread_pool, spawner_thread, &spawner_ptr,
+                      sizeof (spawner_ptr), "load client spawner"))
+    {
+      error ("Could not create spawner thread");
+      goto cleanup;
+    }
+
+  if (reactor_create_threads (&ctx.thread_pool, config, ctx.rctx) == S_FAILURE)
+    goto cleanup;
+
+  if (pthread_mutex_lock (&ctx.mutex) != 0)
+    {
+      error ("Could not lock spawner mutex");
+      goto cleanup;
+    }
+
+  while (!ctx.done)
+    {
+      if (pthread_cond_wait (&ctx.cond_sem, &ctx.mutex) != 0)
+        {
+          error ("Could not wait on spawner condition");
+          break;
+        }
+    }
+
+  if (pthread_mutex_unlock (&ctx.mutex) != 0)
+    error ("Could not unlock spawner mutex");
+
+  status = S_SUCCESS;
+
+cleanup:
+  spawner_context_destroy (&ctx);
+  return (status);
+}

--- a/src/load_client.h
+++ b/src/load_client.h
@@ -1,0 +1,9 @@
+#ifndef LOAD_CLIENT_H
+#define LOAD_CLIENT_H
+
+#include "common.h"
+#include "config.h"
+
+status_t spawn_load_clients (config_t *config);
+
+#endif // LOAD_CLIENT_H

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "common.h"
 #include "config.h"
 #include "gen.h"
+#include "load_client.h"
 #include "log.h"
 #include "multi.h"
 #include "reactor_server.h"
@@ -43,11 +44,11 @@ usage (char *first_arg)
            "\t-m, --multi              multithreaded mode\n"
            "\t-g, --gen                generator mode\n"
            "\t-c, --client             synchronous client mode\n"
-           "\t-L, --load-clients uint  spawn N load clients\n"
            "\t-S, --server             synchronous server mode\n"
            "\t-v, --async-client       asynchronous client mode\n"
            "\t-w, --async-server       asynchronous server mode\n"
            "\t-R, --reactor-server     reactor server mode\n"
+           "\t-L, --load-clients uint  spawn N load clients\n"
            "brute modes:\n"
            "\t-i, --iter               iterative bruteforce\n"
            "\t-r, --rec                recursive bruteforce\n"
@@ -68,7 +69,6 @@ parse_params (config_t *config, int argc, char *argv[])
           { "threads", required_argument, 0, 't' },
           { "port", required_argument, 0, 'p' },
           { "addr", required_argument, 0, 'A' },
-          { "load-clients", required_argument, 0, 'L' },
           { "timeout", required_argument, 0, 'T' },
           { "single", no_argument, 0, 's' },
           { "multi", no_argument, 0, 'm' },
@@ -78,6 +78,7 @@ parse_params (config_t *config, int argc, char *argv[])
           { "async-client", no_argument, 0, 'v' },
           { "async-server", no_argument, 0, 'w' },
           { "reactor-server", no_argument, 0, 'R' },
+          { "load-clients", required_argument, 0, 'L' },
           { "iter", no_argument, 0, 'i' },
           { "rec", no_argument, 0, 'r' },
           { "rec-gen", no_argument, 0, 'y' },
@@ -155,16 +156,6 @@ parse_params (config_t *config, int argc, char *argv[])
         case 'c':
           config->run_mode = RM_CLIENT;
           break;
-        case 'L':
-          config->number_of_threads = atoi (optarg);
-          if (config->number_of_threads < 1)
-            {
-              error ("Number of load clients to spawn must be a number "
-                     "greater than 1");
-              return (S_FAILURE);
-            }
-          config->run_mode = RM_LOAD_CLIENT;
-          break;
         case 'S':
           config->run_mode = RM_SERVER;
           break;
@@ -185,6 +176,16 @@ parse_params (config_t *config, int argc, char *argv[])
           break;
         case 'y':
           config->brute_mode = BM_REC_GEN;
+          break;
+        case 'L':
+          config->number_of_threads = atoi (optarg);
+          if (config->number_of_threads < 1)
+            {
+              error ("Number of load clients to spawn must be a number "
+                     "greater than 1");
+              return (S_FAILURE);
+            }
+          config->run_mode = RM_LOAD_CLIENT;
           break;
         case 'h':
           usage (argv[0]);
@@ -245,11 +246,11 @@ main (int argc, char *argv[])
     case RM_CLIENT:
       run_client (&config, sync_client_find_password);
       return (EXIT_SUCCESS);
-    case RM_LOAD_CLIENT:
-      spawn_clients (&config, NULL);
-      return (EXIT_SUCCESS);
     case RM_REACTOR_SERVER:
       is_found = run_reactor_server (&task, &config);
+      break;
+    case RM_LOAD_CLIENT:
+      spawn_load_clients (&config);
       break;
     }
 

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -1,0 +1,120 @@
+#include "priority_queue.h"
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LCHILD(idx) ((2 * (idx)) + 1)
+#define RCHILD(idx) ((2 * (idx)) + 2)
+#define PARENT(idx) (((idx) - 1) / 2)
+#define HEAP_AT(pq, idx) ((char *)(pq)->heap + ((idx) * (pq)->unit_size))
+
+status_t
+priority_queue_init (priority_queue_t *pq, size_t cap, size_t unit_size,
+                     pq_comparator_t cmp)
+{
+  if (!(pq->heap = calloc (cap, unit_size)))
+    return (S_FAILURE);
+  pq->size = 0;
+  pq->cap = cap;
+  pq->cmp = cmp;
+  pq->unit_size = unit_size;
+  if (pthread_mutex_init (&pq->mutex, NULL) != 0)
+    {
+      free (pq->heap);
+      pq->heap = NULL;
+      return (S_FAILURE);
+    }
+  return (S_SUCCESS);
+}
+
+static void
+swap (priority_queue_t *pq, size_t i, size_t p)
+{
+  char temp[pq->unit_size];
+  memcpy (temp, HEAP_AT (pq, i), pq->unit_size);
+  memcpy (HEAP_AT (pq, i), HEAP_AT (pq, p), pq->unit_size);
+  memcpy (HEAP_AT (pq, p), temp, pq->unit_size);
+}
+
+status_t
+priority_queue_push (priority_queue_t *pq, void *payload)
+{
+  status_t ret = S_FAILURE;
+  pthread_mutex_lock (&pq->mutex);
+  if (pq->size == pq->cap)
+    goto unlock;
+
+  memcpy (HEAP_AT (pq, pq->size), payload, pq->unit_size);
+  size_t i = pq->size++;
+  while (i > 0)
+    {
+      size_t p = PARENT (i);
+      if (pq->cmp (HEAP_AT (pq, i), HEAP_AT (pq, p)) >= 0)
+        break;
+      swap (pq, i, p);
+      i = p;
+    }
+  ret = S_SUCCESS;
+unlock:
+  pthread_mutex_unlock (&pq->mutex);
+  return (ret);
+}
+
+status_t
+priority_queue_top (priority_queue_t *pq, void *payload)
+{
+  status_t ret = S_FAILURE;
+  pthread_mutex_lock (&pq->mutex);
+  if (pq->size == 0)
+    goto unlock;
+  memcpy (payload, HEAP_AT (pq, 0), pq->unit_size);
+  ret = S_SUCCESS;
+unlock:
+  pthread_mutex_unlock (&pq->mutex);
+  return (ret);
+}
+
+status_t
+priority_queue_pop (priority_queue_t *pq)
+{
+  status_t ret = S_FAILURE;
+  pthread_mutex_lock (&pq->mutex);
+  if (pq->size == 0)
+    goto unlock;
+
+  memcpy (pq->heap, HEAP_AT (pq, --pq->size), pq->unit_size);
+  size_t i = 0;
+  while (true)
+    {
+      size_t l = LCHILD (i), r = RCHILD (i);
+      size_t smallest = i;
+
+      if (l < pq->size && pq->cmp (HEAP_AT (pq, l), HEAP_AT (pq, i)) < 0)
+        smallest = l;
+
+      if (r < pq->size
+          && pq->cmp (HEAP_AT (pq, r), HEAP_AT (pq, smallest)) < 0)
+        smallest = r;
+
+      if (smallest == i)
+        break;
+
+      swap (pq, i, smallest);
+      i = smallest;
+    }
+  ret = S_SUCCESS;
+unlock:
+  pthread_mutex_unlock (&pq->mutex);
+  return (ret);
+}
+
+void
+priority_queue_destroy (priority_queue_t *pq)
+{
+  pthread_mutex_destroy (&pq->mutex);
+  free (pq->heap);
+  pq->heap = NULL;
+  pq->size = 0;
+}

--- a/src/priority_queue.h
+++ b/src/priority_queue.h
@@ -1,0 +1,27 @@
+#ifndef PRIORITY_QUEUE_H
+#define PRIORITY_QUEUE_H
+
+#include "common.h"
+
+#include <pthread.h>
+
+typedef int (*pq_comparator_t) (const void *lhs, const void *rhs);
+
+typedef struct priority_queue_t
+{
+  void *heap;
+  size_t size;
+  size_t cap;
+  pq_comparator_t cmp;
+  size_t unit_size;
+  pthread_mutex_t mutex;
+} priority_queue_t;
+
+status_t priority_queue_init (priority_queue_t *pq, size_t cap,
+                              size_t unit_size, pq_comparator_t cmp);
+status_t priority_queue_push (priority_queue_t *pq, void *payload);
+status_t priority_queue_top (priority_queue_t *pq, void *payload);
+status_t priority_queue_pop (priority_queue_t *pq);
+void priority_queue_destroy (priority_queue_t *pq);
+
+#endif /* PRIORITY_QUEUE_H */

--- a/src/reactor_common.c
+++ b/src/reactor_common.c
@@ -1,0 +1,423 @@
+#include "reactor_common.h"
+
+#include "log.h"
+
+#include <event2/event.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+status_t
+reactor_context_init (reactor_context_t *ctx)
+{
+  if (queue_init (&ctx->jobs_queue, sizeof (job_t)) != QS_SUCCESS)
+    {
+      error ("Could not initialize jobs queue");
+      return (S_FAILURE);
+    }
+  ctx->ev_base = event_base_new ();
+  if (!ctx->ev_base)
+    {
+      error ("Could not initialize event base");
+      queue_destroy (&ctx->jobs_queue);
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+void
+reactor_context_stop (reactor_context_t *ctx)
+{
+  if (!ctx)
+    return;
+
+  if (ctx->ev_base)
+    event_base_loopbreak (ctx->ev_base);
+
+  if (queue_cancel (&ctx->jobs_queue) == QS_FAILURE)
+    error ("Could not cancel reactor jobs queue");
+}
+
+status_t
+reactor_context_destroy (reactor_context_t *ctx)
+{
+  if (queue_destroy (&ctx->jobs_queue) != QS_SUCCESS)
+    {
+      error ("Could not destroy jobs queue");
+      return (S_FAILURE);
+    }
+  event_base_free (ctx->ev_base);
+
+  return (S_SUCCESS);
+}
+
+static void
+reactor_job_drain_cb (void *payload, void *arg)
+{
+  (void)arg;
+
+  job_t *job = payload;
+  if (job->release_fn)
+    job->release_fn (job->arg);
+}
+
+status_t
+reactor_context_drain_jobs (reactor_context_t *ctx)
+{
+  return (queue_drain (&ctx->jobs_queue, reactor_job_drain_cb, NULL)
+                  == QS_SUCCESS
+              ? S_SUCCESS
+              : S_FAILURE);
+}
+
+reactor_push_status_t
+reactor_push_job (reactor_context_t *rctr_ctx, void *arg,
+                  status_t (*job_func) (void *), job_release_fn release_fn)
+{
+  job_t job = {
+    .arg = arg,
+    .job_func = job_func,
+    .release_fn = release_fn,
+  };
+
+  queue_status_t qs = queue_push_back (&rctr_ctx->jobs_queue, &job);
+  if (qs == QS_SUCCESS)
+    return (RPS_SUCCESS);
+
+  if (qs == QS_INACTIVE)
+    return (RPS_INACTIVE);
+
+  error ("Could not push job to a job queue");
+  return (RPS_FAILURE);
+}
+
+typedef struct reactor_event_node_t
+{
+  const struct event *ev;
+  struct reactor_event_node_t *next;
+  struct reactor_event_node_t *prev;
+} reactor_event_node_t;
+
+typedef struct reactor_event_list_t
+{
+  reactor_event_node_t head;
+} reactor_event_list_t;
+
+static int
+reactor_collect_events_cb (const struct event_base *ev_base,
+                           const struct event *ev, void *arg)
+{
+  (void)ev_base;
+
+  reactor_event_list_t *list = arg;
+  reactor_event_node_t *node = calloc (1, sizeof (*node));
+  if (!node)
+    return (-1);
+
+  node->next = &list->head;
+  node->prev = list->head.prev;
+  node->ev = ev;
+
+  list->head.prev->next = node;
+  list->head.prev = node;
+
+  return (0);
+}
+
+status_t
+reactor_for_each_event_snapshot (reactor_context_t *ctx,
+                                 reactor_event_visit_fn visit, void *arg)
+{
+  if (!ctx || !ctx->ev_base || !visit)
+    return (S_FAILURE);
+
+  reactor_event_list_t list;
+  list.head.prev = &list.head;
+  list.head.next = &list.head;
+  list.head.ev = NULL;
+
+  if (event_base_foreach_event (ctx->ev_base, reactor_collect_events_cb, &list)
+      != 0)
+    return (S_FAILURE);
+
+  reactor_event_node_t *curr = list.head.next;
+  while (curr->ev)
+    {
+      reactor_event_node_t *next = curr->next;
+      visit (curr->ev, arg);
+      free (curr);
+      curr = next;
+    }
+
+  return (S_SUCCESS);
+}
+
+status_t
+reactor_event_del_free (struct event *ev)
+{
+  if (!ev)
+    return (S_SUCCESS);
+
+  status_t status = S_SUCCESS;
+
+  if (event_del (ev) == -1)
+    {
+      error ("Could not delete event");
+      status = S_FAILURE;
+    }
+
+  event_free (ev);
+  return (status);
+}
+
+void *
+reactor_event_loop (void *arg)
+{
+  reactor_context_t *ctx = arg;
+  if (event_base_loop (ctx->ev_base, EVLOOP_NO_EXIT_ON_EMPTY) != 0)
+    error ("Could not dispatch the event loop");
+
+  return (NULL);
+}
+
+void *
+reactor_worker_loop (void *arg)
+{
+  reactor_context_t *ctx = *(reactor_context_t **)arg;
+
+  for (;;)
+    {
+      job_t job;
+      queue_status_t qs = queue_pop (&ctx->jobs_queue, &job);
+      if (qs == QS_INACTIVE)
+        break;
+      if (qs != QS_SUCCESS)
+        {
+          error ("Could not pop a job from a job queue");
+          break;
+        }
+
+      trace ("Got job from a job queue");
+
+      status_t st = job.job_func (job.arg);
+
+      if (job.release_fn)
+        job.release_fn (job.arg);
+
+      if (st == S_FAILURE)
+        {
+          error ("Could not complete a job");
+          break;
+        }
+    }
+
+  event_base_loopbreak (ctx->ev_base);
+  return (NULL);
+}
+
+status_t
+reactor_create_threads (thread_pool_t *tp, config_t *config,
+                        reactor_context_t *ptr)
+{
+  long number_of_threads
+      = (config->number_of_threads > 2) ? config->number_of_threads - 2 : 1;
+  if (create_threads (tp, number_of_threads, reactor_worker_loop, &ptr,
+                      sizeof (ptr), "i/o handler")
+      == 0)
+    return (S_FAILURE);
+  trace ("Created I/O handler thread");
+
+  if (!thread_create (tp, reactor_event_loop, ptr, sizeof (*ptr),
+                      "event loop dispatcher"))
+    return (S_FAILURE);
+
+  trace ("Created event loop dispatcher thread");
+
+  return (S_SUCCESS);
+}
+
+status_t
+reactor_conn_init (reactor_conn_t *conn, reactor_context_t *rctr_ctx,
+                   evutil_socket_t fd, event_callback_fn on_read, void *arg)
+{
+  memset (conn, 0, sizeof (*conn));
+
+  conn->fd = fd;
+
+  if (evutil_make_socket_nonblocking (conn->fd) != 0)
+    {
+      error ("Could not change socket to be nonblocking");
+      return (S_FAILURE);
+    }
+
+  conn->read_event
+      = event_new (rctr_ctx->ev_base, fd, EV_READ | EV_PERSIST, on_read, arg);
+  if (!conn->read_event)
+    {
+      error ("Could not create read event");
+      conn->fd = -1;
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+status_t
+reactor_conn_enable_read (reactor_conn_t *conn)
+{
+  if (!conn || !conn->read_event)
+    return (S_FAILURE);
+
+  if (event_add (conn->read_event, NULL) != 0)
+    {
+      error ("Could not add read event to event base");
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+status_t
+reactor_conn_disable_read (reactor_conn_t *conn)
+{
+  if (!conn || !conn->read_event)
+    return (S_SUCCESS);
+
+  if (event_del (conn->read_event) == -1)
+    {
+      error ("Could not delete read event");
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+status_t
+reactor_conn_destroy (reactor_conn_t *conn)
+{
+  if (!conn)
+    return (S_SUCCESS);
+
+  status_t status = S_SUCCESS;
+
+  if (conn->read_event)
+    {
+      if (event_del (conn->read_event) == -1)
+        {
+          error ("Could not delete read event");
+          status = S_FAILURE;
+        }
+
+      event_free (conn->read_event);
+      conn->read_event = NULL;
+    }
+
+  if (conn->fd >= 0)
+    {
+      shutdown (conn->fd, SHUT_RDWR);
+
+      if (close (conn->fd) != 0)
+        {
+          error ("Could not close socket");
+          status = S_FAILURE;
+        }
+
+      conn->fd = -1;
+    }
+
+  return (status);
+}
+
+static void
+reactor_iov_advance (struct iovec *vec, int *vec_sz, size_t bytes)
+{
+  int i = 0;
+
+  while (i < *vec_sz && bytes > 0 && vec[i].iov_len <= bytes)
+    {
+      bytes -= vec[i].iov_len;
+      ++i;
+    }
+
+  *vec_sz -= i;
+  memmove (&vec[0], &vec[i], sizeof (struct iovec) * (size_t)*vec_sz);
+
+  if (*vec_sz > 0 && bytes > 0)
+    {
+      vec[0].iov_base = (char *)vec[0].iov_base + bytes;
+      vec[0].iov_len -= bytes;
+    }
+}
+
+static reactor_io_status_t
+reactor_writev_advance (int fd, struct iovec *vec, int *vec_sz)
+{
+  ssize_t written = writev (fd, vec, *vec_sz);
+
+  if (written < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        return (RIO_PENDING);
+
+      return (RIO_ERROR);
+    }
+
+  if (written == 0)
+    return (RIO_CLOSED);
+
+  reactor_iov_advance (vec, vec_sz, (size_t)written);
+
+  return (*vec_sz == 0 ? RIO_DONE : RIO_PENDING);
+}
+
+static reactor_io_status_t
+reactor_readv_advance (int fd, struct iovec *vec, int *vec_sz)
+{
+  ssize_t nread = readv (fd, vec, *vec_sz);
+
+  if (nread < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        return (RIO_PENDING);
+
+      return (RIO_ERROR);
+    }
+
+  if (nread == 0)
+    return (RIO_CLOSED);
+
+  reactor_iov_advance (vec, vec_sz, (size_t)nread);
+
+  return (*vec_sz == 0 ? RIO_DONE : RIO_PENDING);
+}
+
+reactor_io_status_t
+reactor_conn_readv (reactor_conn_t *conn, struct iovec *vec, int *vec_sz)
+{
+  if (!conn || conn->fd < 0)
+    return (RIO_CLOSED);
+
+  return (reactor_readv_advance (conn->fd, vec, vec_sz));
+}
+
+status_t
+write_state_write_wrapper (int socket_fd, struct iovec *vec, int *vec_sz)
+{
+  reactor_io_status_t status = reactor_writev_advance (socket_fd, vec, vec_sz);
+
+  if (status == RIO_ERROR || status == RIO_CLOSED)
+    {
+      error ("Could not send data");
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
+inline status_t
+write_state_write (int socket_fd, write_state_t *write_state)
+{
+  return (write_state_write_wrapper (socket_fd, write_state->base_state.vec,
+                                     &write_state->base_state.vec_sz));
+}

--- a/src/reactor_common.h
+++ b/src/reactor_common.h
@@ -1,0 +1,96 @@
+#ifndef REACTOR_COMMON_H
+#define REACTOR_COMMON_H
+
+#include "common.h"
+#include "config.h"
+#include "queue.h"
+#include "thread_pool.h"
+
+#include <event2/event.h>
+
+typedef struct reactor_context_t
+{
+  queue_t jobs_queue;
+  struct event_base *ev_base;
+} reactor_context_t;
+
+status_t reactor_context_init (reactor_context_t *ctx);
+void reactor_context_stop (reactor_context_t *ctx);
+status_t reactor_context_destroy (reactor_context_t *ctx);
+status_t reactor_context_drain_jobs (reactor_context_t *ctx);
+
+typedef enum reactor_push_status_t
+{
+  RPS_SUCCESS,
+  RPS_INACTIVE,
+  RPS_FAILURE,
+} reactor_push_status_t;
+
+typedef void (*job_release_fn) (void *);
+
+typedef struct job_t
+{
+  void *arg;
+  status_t (*job_func) (void *);
+  job_release_fn release_fn;
+} job_t;
+
+reactor_push_status_t reactor_push_job (reactor_context_t *rctr_ctx, void *arg,
+                                        status_t (*job_func) (void *),
+                                        job_release_fn release_fn);
+
+typedef void (*reactor_event_visit_fn) (const struct event *ev, void *arg);
+
+status_t reactor_for_each_event_snapshot (reactor_context_t *ctx,
+                                          reactor_event_visit_fn visit,
+                                          void *arg);
+status_t reactor_event_del_free (struct event *ev);
+
+status_t reactor_create_threads (thread_pool_t *tp, config_t *config,
+                                 reactor_context_t *ptr);
+
+typedef enum reactor_io_status
+{
+  RIO_DONE,
+  RIO_PENDING,
+  RIO_CLOSED,
+  RIO_ERROR,
+} reactor_io_status_t;
+
+typedef struct reactor_conn_t
+{
+  struct event *read_event;
+  evutil_socket_t fd;
+} reactor_conn_t;
+
+status_t reactor_conn_init (reactor_conn_t *conn, reactor_context_t *rctr_ctx,
+                            evutil_socket_t fd, event_callback_fn on_read,
+                            void *arg);
+status_t reactor_conn_enable_read (reactor_conn_t *conn);
+status_t reactor_conn_disable_read (reactor_conn_t *conn);
+status_t reactor_conn_destroy (reactor_conn_t *conn);
+
+reactor_io_status_t reactor_conn_readv (reactor_conn_t *conn,
+                                        struct iovec *vec, int *vec_sz);
+
+typedef struct io_state_t
+{
+  struct iovec vec[2];
+  int32_t vec_sz;
+  command_t cmd;
+} io_state_t;
+
+typedef struct write_state_t
+{
+  io_state_t base_state;
+  struct iovec vec_extra[3];
+  command_t cmd_extra;
+  int32_t length;
+  int32_t vec_extra_sz;
+} write_state_t;
+
+status_t write_state_write_wrapper (int socket_fd, struct iovec *vec,
+                                    int *vec_sz);
+status_t write_state_write (int socket_fd, write_state_t *write_state);
+
+#endif // REACTOR_COMMON_H

--- a/src/reactor_server.c
+++ b/src/reactor_server.c
@@ -1,15 +1,14 @@
 #include "reactor_server.h"
 
-#include "brute.h"
 #include "brute_engine.h"
 #include "common.h"
 #include "log.h"
 #include "queue.h"
+#include "reactor_common.h"
 #include "server_common.h"
 #include "thread_pool.h"
 
 #include <assert.h>
-#include <errno.h>
 #include <event2/event.h>
 #include <event2/listener.h>
 #include <event2/thread.h>
@@ -23,14 +22,6 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
-typedef enum push_status
-{
-  PS_SUCCESS,
-  PS_SKIPPED,
-  PS_FAILURE,
-  PS_DESTROYED,
-} push_status_t;
-
 typedef enum
 {
   CS_ACTIVE,
@@ -39,6 +30,13 @@ typedef enum
   CS_CLOSING,
 } client_state_t;
 
+typedef enum client_advance_state_t
+{
+  CAS_IDLE,
+  CAS_QUEUED,
+  CAS_REQUEUED,
+} client_advance_state_t;
+
 typedef struct rsrv_context_t
 {
   srv_listener_t listener;
@@ -46,27 +44,10 @@ typedef struct rsrv_context_t
   thread_pool_t thread_pool;
   config_t *config;
 
-  queue_t jobs_queue;
+  reactor_context_t reactor;
   queue_t starving_clients;
-  struct event_base *ev_base;
   bool shutting_down;
 } rsrv_context_t;
-
-typedef struct io_state_t
-{
-  struct iovec vec[2];
-  int32_t vec_sz;
-  command_t cmd;
-} io_state_t;
-
-typedef struct write_state_t
-{
-  io_state_t base_state;
-  struct iovec vec_extra[3];
-  command_t cmd_extra;
-  unsigned long length;
-  int32_t vec_extra_sz;
-} write_state_t;
 
 typedef struct task_slot_t
 {
@@ -76,9 +57,8 @@ typedef struct task_slot_t
 
 typedef struct client_context_t
 {
-  struct event *read_event;
   rsrv_context_t *rsrv_ctx;
-  evutil_socket_t socket_fd;
+  reactor_conn_t conn;
   client_state_t state;
   task_slot_t task_slots[QUEUE_SIZE];
   queue_t free_slot_idx;
@@ -87,19 +67,15 @@ typedef struct client_context_t
   result_t read_buffer;
   pthread_mutex_t mutex;
   _Atomic int ref_count;
+  client_advance_state_t advance_state;
+  bool starving_queued;
+  bool has_reserved_task;
+  task_t reserved_task;
 } client_context_t;
 
-typedef struct event_node_t
-{
-  const struct event *ev;
-  struct event_node_t *next;
-  struct event_node_t *prev;
-} event_node_t;
-
-typedef struct event_list_t
-{
-  event_node_t head;
-} event_list_t;
+static void handle_read (evutil_socket_t socket_fd, short what, void *arg);
+static void client_context_destroy (client_context_t *ctx);
+static status_t client_advance_job (void *arg);
 
 static void
 client_disconnect (client_context_t *ctx)
@@ -124,8 +100,6 @@ client_try_ref (client_context_t *ctx)
   return (true);
 }
 
-static void client_context_destroy (client_context_t *ctx);
-
 static bool
 client_unref (client_context_t *ctx)
 {
@@ -136,46 +110,33 @@ client_unref (client_context_t *ctx)
   if (old == 1)
     {
       client_context_destroy (ctx);
-      return true;
+      return (true);
     }
 
-  return false;
+  return (false);
+}
+
+static void
+client_unref_release (void *arg)
+{
+  client_unref (arg);
 }
 
 static void
 client_release_event_ref (client_context_t *ctx)
 {
   pthread_mutex_lock (&ctx->mutex);
-  struct event *ev = ctx->read_event;
-  ctx->read_event = NULL;
+  struct event *ev = ctx->conn.read_event;
+  ctx->conn.read_event = NULL;
   pthread_mutex_unlock (&ctx->mutex);
 
   if (!ev)
     return;
 
-  if (event_del (ev) == -1)
-    error ("Could not delete read event");
-  event_free (ev);
+  if (reactor_event_del_free (ev) == S_FAILURE)
+    error ("Could not delete/free client read event");
 
   client_unref (ctx);
-}
-
-static bool
-client_is_closing (client_context_t *ctx)
-{
-  pthread_mutex_lock (&ctx->mutex);
-  bool is_closing = ctx->state == CS_CLOSING;
-  pthread_mutex_unlock (&ctx->mutex);
-
-  return (is_closing);
-}
-
-static void
-jobs_queue_unref_cb (void *payload, void *arg)
-{
-  (void)arg;
-  job_t *job = payload;
-  client_unref (job->arg);
 }
 
 static void
@@ -186,50 +147,20 @@ starving_clients_unref_cb (void *payload, void *arg)
   client_unref (client);
 }
 
-static int
-collect_events_cb (const struct event_base *ev_base, const struct event *ev,
-                   void *arg)
-{
-  (void)ev_base; /* to suppress the "unused parameter" warning */
-
-  event_list_t *list = arg;
-  event_node_t *node = calloc (1, sizeof (*node));
-  if (!node)
-    return -1;
-  node->next = &list->head;
-  node->prev = list->head.prev;
-  node->ev = ev;
-
-  list->head.prev->next = node;
-  list->head.prev = node;
-
-  return 0;
-}
-
-static void handle_read (evutil_socket_t socket_fd, short what, void *arg);
-
 static void
-clients_cleanup (event_list_t *list)
+release_client_event_visit (const struct event *ev, void *arg)
 {
-  event_node_t *curr = list->head.next;
-  while (curr->ev)
-    {
-      event_node_t *dummy = curr;
-      if (event_get_callback (curr->ev) == handle_read)
-        {
-          client_context_t *ctx = event_get_callback_arg (curr->ev);
-          if (ctx)
-            {
-              trace ("Releasing client event reference");
-              client_release_event_ref (ctx);
-            }
-        }
+  (void)arg;
 
-      curr->prev->next = curr->next;
-      curr->next->prev = curr->prev;
-      curr = curr->next;
-      free (dummy);
-    }
+  if (event_get_callback (ev) != handle_read)
+    return;
+
+  client_context_t *ctx = event_get_callback_arg (ev);
+  if (!ctx)
+    return;
+
+  trace ("Releasing client event reference");
+  client_release_event_ref (ctx);
 }
 
 static client_context_t *
@@ -239,18 +170,26 @@ client_context_init (rsrv_context_t *rsrv_ctx, evutil_socket_t fd)
   if (!client_ctx)
     {
       error ("Could not allocate client context");
+      shutdown (fd, SHUT_RDWR);
+      if (close (fd) != 0)
+        error ("Could not close client socket");
       return (NULL);
     }
+
+  /* Make sure that we won't accidentally close the stdin on `goto fail`. */
+  client_ctx->conn.fd = -1;
+
+  bool mutex_initialized = false;
+  bool free_slot_idx_initialized = false;
 
   if (pthread_mutex_init (&client_ctx->mutex, NULL) != 0)
     {
       error ("Could not initialize client mutex");
-      free (client_ctx);
-      return (NULL);
+      goto fail;
     }
-  client_ctx->state = CS_ACTIVE;
+  mutex_initialized = true;
 
-  client_ctx->socket_fd = fd;
+  client_ctx->state = CS_ACTIVE;
   client_ctx->rsrv_ctx = rsrv_ctx;
   client_ctx->read_state.vec[0].iov_base = &client_ctx->read_buffer;
   client_ctx->read_state.vec[0].iov_len = sizeof (client_ctx->read_buffer);
@@ -261,7 +200,6 @@ client_context_init (rsrv_context_t *rsrv_ctx, evutil_socket_t fd)
   write_state_t *write_state = &client_ctx->write_state;
   io_state_t *write_state_base = &write_state->base_state;
 
-  /* Set up vector for hash sending */
   write_state_base->cmd = CMD_HASH;
   write_state_base->vec[0].iov_base = &write_state_base->cmd;
   write_state_base->vec[0].iov_len = sizeof (write_state_base->cmd);
@@ -269,9 +207,8 @@ client_context_init (rsrv_context_t *rsrv_ctx, evutil_socket_t fd)
   write_state_base->vec[1].iov_len = HASH_LENGTH;
   write_state_base->vec_sz = 2;
 
-  /* Set up vector for alphabet sending */
   write_state->cmd_extra = CMD_ALPH;
-  write_state->length = strlen (config->alph);
+  write_state->length = (int32_t)strlen (config->alph);
   write_state->vec_extra[0].iov_base = &write_state->cmd_extra;
   write_state->vec_extra[0].iov_len = sizeof (write_state->cmd_extra);
   write_state->vec_extra[1].iov_base = &write_state->length;
@@ -280,12 +217,12 @@ client_context_init (rsrv_context_t *rsrv_ctx, evutil_socket_t fd)
   write_state->vec_extra[2].iov_len = write_state->length;
   write_state->vec_extra_sz = 3;
 
-  bool free_slot_idx_initialized = false;
   if (queue_init (&client_ctx->free_slot_idx, sizeof (int)) != QS_SUCCESS)
     {
       error ("Could not initialize free slot queue");
       goto fail;
     }
+
   free_slot_idx_initialized = true;
   for (int i = 0; i < QUEUE_SIZE; ++i)
     if (queue_push (&client_ctx->free_slot_idx, &i) != QS_SUCCESS)
@@ -294,33 +231,32 @@ client_context_init (rsrv_context_t *rsrv_ctx, evutil_socket_t fd)
         goto fail;
       }
 
-  if (evutil_make_socket_nonblocking (client_ctx->socket_fd) != 0)
+  if (reactor_conn_init (&client_ctx->conn, &rsrv_ctx->reactor, fd,
+                         handle_read, client_ctx)
+      != S_SUCCESS)
     {
-      error ("Could not change socket to be nonblocking");
+      error ("Could not initialize reactor connection");
       goto fail;
     }
 
-  client_ctx->read_event
-      = event_new (rsrv_ctx->ev_base, client_ctx->socket_fd,
-                   EV_READ | EV_PERSIST, handle_read, client_ctx);
-  if (!client_ctx->read_event)
-    {
-      error ("Could not create read event");
-      goto fail;
-    }
   client_ctx->ref_count = 1;
+
+  /* The read event owns one client reference until `client_release_event_ref`.
+   */
+  client_try_ref (client_ctx);
 
   return (client_ctx);
 
 fail:
-  if (client_ctx->read_event)
-    event_free (client_ctx->read_event);
+  reactor_conn_destroy (&client_ctx->conn);
 
   if (free_slot_idx_initialized
       && queue_destroy (&client_ctx->free_slot_idx) != QS_SUCCESS)
     error ("Could not destroy free slot queue");
 
-  pthread_mutex_destroy (&client_ctx->mutex);
+  if (mutex_initialized)
+    pthread_mutex_destroy (&client_ctx->mutex);
+
   free (client_ctx);
   return (NULL);
 }
@@ -336,8 +272,8 @@ rsrv_context_init (rsrv_context_t *ctx, config_t *config)
 
   bool listener_initialized = false;
   bool engine_initialized = false;
+  bool reactor_initialized = false;
   bool starving_clients_initialized = false;
-  bool jobs_queue_initialized = false;
 
   if (srv_listener_init (&ctx->listener, config) == S_FAILURE)
     {
@@ -359,6 +295,13 @@ rsrv_context_init (rsrv_context_t *ctx, config_t *config)
       goto fail;
     }
 
+  if (reactor_context_init (&ctx->reactor) == S_FAILURE)
+    {
+      error ("Could not initialize reactor context");
+      goto fail;
+    }
+  reactor_initialized = true;
+
   if (queue_init (&ctx->starving_clients, sizeof (client_context_t *))
       == QS_FAILURE)
     {
@@ -367,41 +310,22 @@ rsrv_context_init (rsrv_context_t *ctx, config_t *config)
     }
   starving_clients_initialized = true;
 
-  if (queue_init (&ctx->jobs_queue, sizeof (job_t)) == QS_FAILURE)
-    {
-      error ("Could not initialize jobs queue");
-      goto fail;
-    }
-  jobs_queue_initialized = true;
-
-  ctx->ev_base = event_base_new ();
-  if (!ctx->ev_base)
-    {
-      error ("Could not initialize event base");
-      goto fail;
-    }
-
   if (evutil_make_socket_nonblocking (ctx->listener.listen_fd) < 0)
     {
       error ("Could not change socket to be nonblocking");
       goto fail;
     }
 
-  return S_SUCCESS;
+  return (S_SUCCESS);
 
 fail:
-  if (ctx->ev_base)
-    {
-      event_base_free (ctx->ev_base);
-      ctx->ev_base = NULL;
-    }
-
-  if (jobs_queue_initialized && queue_destroy (&ctx->jobs_queue) == QS_FAILURE)
-    error ("Could not destroy jobs queue during init cleanup");
-
   if (starving_clients_initialized
       && queue_destroy (&ctx->starving_clients) == QS_FAILURE)
     error ("Could not destroy starving clients queue during init cleanup");
+
+  if (reactor_initialized
+      && reactor_context_destroy (&ctx->reactor) == S_FAILURE)
+    error ("Could not destroy reactor context during init cleanup");
 
   if (engine_initialized && brute_engine_destroy (&ctx->engine) == S_FAILURE)
     error ("Could not destroy brute engine during init cleanup");
@@ -410,7 +334,7 @@ fail:
       && srv_listener_destroy (&ctx->listener) == S_FAILURE)
     error ("Could not destroy server listener during init cleanup");
 
-  return S_FAILURE;
+  return (S_FAILURE);
 }
 
 static void
@@ -418,10 +342,7 @@ reactor_server_context_stop (rsrv_context_t *ctx)
 {
   ctx->shutting_down = true;
 
-  event_base_loopbreak (ctx->ev_base);
-
-  if (queue_cancel (&ctx->jobs_queue) == QS_FAILURE)
-    error ("Could not cancel jobs queue");
+  reactor_context_stop (&ctx->reactor);
 
   if (queue_cancel (&ctx->starving_clients) == QS_FAILURE)
     error ("Could not cancel starving clients queue");
@@ -436,32 +357,25 @@ reactor_server_context_stop (rsrv_context_t *ctx)
 static status_t
 reactor_server_context_destroy (rsrv_context_t *ctx)
 {
-  if (queue_drain (&ctx->jobs_queue, jobs_queue_unref_cb, NULL) != QS_SUCCESS)
-    error ("Could not drain jobs queue");
+  if (reactor_context_drain_jobs (&ctx->reactor) != S_SUCCESS)
+    error ("Could not drain reactor jobs queue");
 
   if (queue_drain (&ctx->starving_clients, starving_clients_unref_cb, NULL)
       != QS_SUCCESS)
     error ("Could not drain starving clients queue");
 
-  if (queue_destroy (&ctx->jobs_queue) == QS_FAILURE)
-    return S_FAILURE;
-
   if (queue_destroy (&ctx->starving_clients) == QS_FAILURE)
-    return S_FAILURE;
+    return (S_FAILURE);
 
-  event_list_t ev_list;
-  ev_list.head.prev = &ev_list.head;
-  ev_list.head.next = &ev_list.head;
-  ev_list.head.ev = NULL;
+  if (reactor_for_each_event_snapshot (&ctx->reactor,
+                                       release_client_event_visit, NULL)
+      == S_FAILURE)
+    error ("Could not snapshot reactor events");
 
-  event_base_foreach_event (ctx->ev_base, collect_events_cb, &ev_list);
-  clients_cleanup (&ev_list);
-  event_base_free (ctx->ev_base);
+  if (reactor_context_destroy (&ctx->reactor) == S_FAILURE)
+    return (S_FAILURE);
 
-  if (brute_engine_destroy (&ctx->engine) == S_FAILURE)
-    return S_FAILURE;
-
-  return S_SUCCESS;
+  return (brute_engine_destroy (&ctx->engine));
 }
 
 static status_t
@@ -470,6 +384,7 @@ return_tasks (client_context_t *ctx)
   status_t status = S_SUCCESS;
 
   pthread_mutex_lock (&ctx->mutex);
+
   for (int i = 0; i < QUEUE_SIZE; ++i)
     {
       if (ctx->task_slots[i].in_use)
@@ -481,9 +396,21 @@ return_tasks (client_context_t *ctx)
               status = S_FAILURE;
               break;
             }
+
           ctx->task_slots[i].in_use = false;
         }
     }
+
+  if (status == S_SUCCESS && ctx->has_reserved_task)
+    {
+      if (brute_engine_return_task (&ctx->rsrv_ctx->engine,
+                                    &ctx->reserved_task)
+          != QS_SUCCESS)
+        status = S_FAILURE;
+      else
+        ctx->has_reserved_task = false;
+    }
+
   pthread_mutex_unlock (&ctx->mutex);
 
   return (status);
@@ -492,8 +419,7 @@ return_tasks (client_context_t *ctx)
 static void
 client_context_destroy (client_context_t *ctx)
 {
-  /* Freed in client_release_event_ref. */
-  assert (ctx->read_event == NULL);
+  assert (ctx->conn.read_event == NULL);
   assert (atomic_load_explicit (&ctx->ref_count, memory_order_relaxed) == 0);
 
   if (!ctx->rsrv_ctx->shutting_down && return_tasks (ctx) == S_FAILURE)
@@ -507,82 +433,127 @@ client_context_destroy (client_context_t *ctx)
 
   trace ("Destroyed free slot queue");
 
-  shutdown (ctx->socket_fd, SHUT_RDWR);
-  if (close (ctx->socket_fd) != 0)
-    error ("Could not close client socket");
-  else
-    trace ("Closed client socket");
+  if (reactor_conn_destroy (&ctx->conn) != S_SUCCESS)
+    error ("Could not destroy reactor connection");
 
   free (ctx);
   trace ("Destroyed client context");
 }
 
-static push_status_t
-push_job_checked (client_context_t *ctx, status_t (*job_func) (void *))
+static void
+client_rollback_scheduled_ref (client_context_t *ctx)
 {
-  if (!client_try_ref (ctx))
-    return (PS_SKIPPED);
+  int old
+      = atomic_fetch_sub_explicit (&ctx->ref_count, 1, memory_order_acq_rel);
 
-  job_t job = {
-    .arg = ctx,
-    .job_func = job_func,
-  };
-  if (queue_push_back (&ctx->rsrv_ctx->jobs_queue, &job) != QS_SUCCESS)
+  /*
+   * Only used to roll back a speculative job reference created while the
+   * caller/current job already owns another live reference.
+   *
+   * This rollback must not destroy the client.
+   */
+  assert (old > 1);
+}
+
+static reactor_push_status_t
+schedule_client_advance (client_context_t *ctx)
+{
+  pthread_mutex_lock (&ctx->mutex);
+
+  if (ctx->state == CS_CLOSING)
     {
-      error ("Could not push job to a job queue");
-      return (client_unref (ctx) ? PS_DESTROYED : PS_FAILURE);
+      pthread_mutex_unlock (&ctx->mutex);
+      return (RPS_INACTIVE);
     }
 
-  return (PS_SUCCESS);
+  if (ctx->advance_state == CAS_QUEUED || ctx->advance_state == CAS_REQUEUED)
+    {
+      ctx->advance_state = CAS_REQUEUED;
+      pthread_mutex_unlock (&ctx->mutex);
+      return RPS_INACTIVE;
+    }
+
+  ctx->advance_state = CAS_QUEUED;
+  atomic_fetch_add_explicit (&ctx->ref_count, 1, memory_order_relaxed);
+
+  pthread_mutex_unlock (&ctx->mutex);
+
+  reactor_push_status_t rps = reactor_push_job (
+      &ctx->rsrv_ctx->reactor, ctx, client_advance_job, client_unref_release);
+  if (rps != RPS_SUCCESS)
+    {
+      pthread_mutex_lock (&ctx->mutex);
+      ctx->advance_state = CAS_IDLE;
+      pthread_mutex_unlock (&ctx->mutex);
+
+      client_rollback_scheduled_ref (ctx);
+      return (rps);
+    }
+
+  return (RPS_SUCCESS);
+}
+
+static reactor_push_status_t
+requeue_client_advance (client_context_t *ctx)
+{
+  pthread_mutex_lock (&ctx->mutex);
+
+  if (ctx->state == CS_CLOSING)
+    {
+      ctx->advance_state = CAS_IDLE;
+      pthread_mutex_unlock (&ctx->mutex);
+      return (RPS_INACTIVE);
+    }
+
+  atomic_fetch_add_explicit (&ctx->ref_count, 1, memory_order_relaxed);
+
+  pthread_mutex_unlock (&ctx->mutex);
+
+  reactor_push_status_t rps = reactor_push_job (
+      &ctx->rsrv_ctx->reactor, ctx, client_advance_job, client_unref_release);
+  if (rps != RPS_SUCCESS)
+    {
+      pthread_mutex_lock (&ctx->mutex);
+      ctx->advance_state = CAS_IDLE;
+      pthread_mutex_unlock (&ctx->mutex);
+
+      client_rollback_scheduled_ref (ctx);
+      return (rps);
+    }
+
+  return (RPS_SUCCESS);
 }
 
 static status_t
-schedule_job (client_context_t *ctx, status_t (*job_func) (void *))
+finish_client_advance (client_context_t *ctx)
 {
-  return (push_job_checked (ctx, job_func) == PS_FAILURE ? S_FAILURE
-                                                         : S_SUCCESS);
-}
+  pthread_mutex_lock (&ctx->mutex);
 
-static status_t
-write_state_write_wrapper (int socket_fd, struct iovec *vec, int *vec_sz)
-{
-  ssize_t written = writev (socket_fd, vec, *vec_sz);
-  if (written < 0)
+  if (ctx->state == CS_CLOSING || ctx->advance_state != CAS_REQUEUED)
     {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        return (S_SUCCESS);
-
-      error ("Could not send config data to client");
-      return (S_FAILURE);
-    }
-  if (written == 0)
-    {
-      error ("Could not send config data to client");
-      return (S_FAILURE);
+      ctx->advance_state = CAS_IDLE;
+      pthread_mutex_unlock (&ctx->mutex);
+      return (S_SUCCESS);
     }
 
-  size_t bytes_written = written;
-  int i = 0;
-  while (i < *vec_sz && bytes_written > 0 && vec[i].iov_len <= bytes_written)
-    bytes_written -= vec[i++].iov_len;
+  ctx->advance_state = CAS_QUEUED;
+  atomic_fetch_add_explicit (&ctx->ref_count, 1, memory_order_relaxed);
 
-  *vec_sz -= i;
-  memmove (&vec[0], &vec[i], sizeof (struct iovec) * (size_t)*vec_sz);
+  pthread_mutex_unlock (&ctx->mutex);
 
-  if (*vec_sz > 0 && bytes_written > 0)
+  reactor_push_status_t rps = reactor_push_job (
+      &ctx->rsrv_ctx->reactor, ctx, client_advance_job, client_unref_release);
+  if (rps != RPS_SUCCESS)
     {
-      vec[0].iov_base = (char *)vec[0].iov_base + bytes_written;
-      vec[0].iov_len -= bytes_written;
+      pthread_mutex_lock (&ctx->mutex);
+      ctx->advance_state = CAS_IDLE;
+      pthread_mutex_unlock (&ctx->mutex);
+
+      client_rollback_scheduled_ref (ctx);
+      return (rps == RPS_INACTIVE ? S_SUCCESS : S_FAILURE);
     }
 
   return (S_SUCCESS);
-}
-
-static inline status_t
-write_state_write (int socket_fd, write_state_t *write_state)
-{
-  return (write_state_write_wrapper (socket_fd, write_state->base_state.vec,
-                                     &write_state->base_state.vec_sz));
 }
 
 static inline status_t
@@ -600,6 +571,7 @@ task_write_state_setup (client_context_t *ctx, int id)
   task->to = task->from;
   task->from = 0;
   task->result.is_correct = false;
+
   io_state_t *write_state_base = &ctx->write_state.base_state;
   write_state_base->cmd = CMD_TASK;
   write_state_base->vec[0].iov_base = &write_state_base->cmd;
@@ -609,156 +581,229 @@ task_write_state_setup (client_context_t *ctx, int id)
   write_state_base->vec_sz = 2;
 }
 
-static status_t create_task_job (void *arg);
-
 static status_t
-send_config_job (void *arg)
+queue_starving_client (client_context_t *ctx, int slot_id)
 {
-  client_context_t *ctx = arg;
-
-  if (client_is_closing (ctx))
-    return (S_SUCCESS);
-
-  status_t status;
-  if (ctx->write_state.base_state.vec_sz != 0)
+  if (queue_push_back (&ctx->free_slot_idx, &slot_id) != QS_SUCCESS)
     {
-      status = write_state_write (ctx->socket_fd, &ctx->write_state);
-      if (status != S_SUCCESS)
-        {
-          error ("Could not send hash to client");
-          client_disconnect (ctx);
-          return (S_SUCCESS);
-        }
-
-      if (ctx->write_state.base_state.vec_sz != 0)
-        return (schedule_job (ctx, send_config_job));
-    }
-
-  status = write_state_write_extra (ctx->socket_fd, &ctx->write_state);
-  if (status != S_SUCCESS)
-    {
-      error ("Could not send alphabet to client");
+      error ("Could not return slot index to free slot queue");
       client_disconnect (ctx);
       return (S_SUCCESS);
     }
 
-  return (schedule_job (ctx, ctx->write_state.vec_extra_sz != 0
-                                 ? send_config_job
-                                 : create_task_job));
-}
-
-static status_t send_task_job (void *arg);
-
-static status_t
-create_task_job (void *arg)
-{
-  client_context_t *ctx = arg;
-
   pthread_mutex_lock (&ctx->mutex);
-  if (ctx->state == CS_CLOSING || ctx->state == CS_WRITING
-      || ctx->state == CS_STARVING)
+
+  if (ctx->state == CS_CLOSING)
     {
       pthread_mutex_unlock (&ctx->mutex);
       return (S_SUCCESS);
     }
+
+  ctx->state = CS_STARVING;
+
+  if (ctx->starving_queued)
+    {
+      pthread_mutex_unlock (&ctx->mutex);
+      return (S_SUCCESS);
+    }
+
+  ctx->starving_queued = true;
+  atomic_fetch_add_explicit (&ctx->ref_count, 1, memory_order_relaxed);
+
+  pthread_mutex_unlock (&ctx->mutex);
+
+  if (queue_push_back (&ctx->rsrv_ctx->starving_clients, &ctx) != QS_SUCCESS)
+    {
+      error ("Could not push client to starving clients queue");
+
+      pthread_mutex_lock (&ctx->mutex);
+      ctx->starving_queued = false;
+      pthread_mutex_unlock (&ctx->mutex);
+
+      client_unref (ctx);
+      client_disconnect (ctx);
+      return (S_SUCCESS);
+    }
+
+  trace ("Queued client in starving clients queue");
+  return (S_SUCCESS);
+}
+
+static bool
+client_take_reserved_task (client_context_t *ctx, task_t *task)
+{
+  pthread_mutex_lock (&ctx->mutex);
+
+  if (!ctx->has_reserved_task)
+    {
+      pthread_mutex_unlock (&ctx->mutex);
+      return (false);
+    }
+
+  *task = ctx->reserved_task;
+  ctx->has_reserved_task = false;
+
+  pthread_mutex_unlock (&ctx->mutex);
+  return (true);
+}
+
+static status_t
+client_prepare_next_task (client_context_t *ctx)
+{
+  pthread_mutex_lock (&ctx->mutex);
+
+  if (ctx->state == CS_CLOSING || ctx->state == CS_STARVING)
+    {
+      pthread_mutex_unlock (&ctx->mutex);
+      return (S_SUCCESS);
+    }
+
   ctx->state = CS_WRITING;
   pthread_mutex_unlock (&ctx->mutex);
 
   int id;
-  queue_status_t qs;
-
-  qs = queue_trypop (&ctx->free_slot_idx, &id);
+  queue_status_t qs = queue_trypop (&ctx->free_slot_idx, &id);
   if (qs != QS_SUCCESS)
     {
       if (qs != QS_EMPTY)
-        client_disconnect (ctx);
-      goto clear_writing_flag;
-    }
+        {
+          error ("Could not pop index from free slot queue");
+          client_disconnect (ctx);
+        }
 
-  task_t *task = &ctx->task_slots[id].task;
-
-  qs = brute_engine_try_take_task (&ctx->rsrv_ctx->engine, task);
-  if (qs == QS_EMPTY)
-    {
-      trace ("No tasks in global queue, add to starving clients");
       pthread_mutex_lock (&ctx->mutex);
-      ctx->state = CS_STARVING;
+      if (ctx->state == CS_WRITING)
+        ctx->state = CS_ACTIVE;
       pthread_mutex_unlock (&ctx->mutex);
 
-      if (queue_push_back (&ctx->free_slot_idx, &id) == QS_FAILURE)
-        {
-          error ("Could not push index to free slot queue");
-          client_disconnect (ctx);
-          return (S_SUCCESS);
-        }
-
-      trace ("Returned slot index %d to free slot queue", id);
-
-      if (!client_try_ref (ctx))
-        return (S_SUCCESS);
-      if (queue_push_back (&ctx->rsrv_ctx->starving_clients, &ctx)
-          == QS_FAILURE)
-        {
-          error ("Could not push client to starving clients queue");
-          if (client_unref (ctx))
-            return (S_SUCCESS);
-          client_disconnect (ctx);
-        }
-
-      trace ("Queued client in starving clients queue");
       return (S_SUCCESS);
     }
 
-  if (qs == QS_FAILURE)
+  task_t task;
+  if (!client_take_reserved_task (ctx, &task))
     {
-      if (queue_push_back (&ctx->free_slot_idx, &id) != QS_SUCCESS)
-        error ("Could not push back id to free slot queue");
-      client_disconnect (ctx);
-      goto clear_writing_flag;
+      qs = brute_engine_try_take_task (&ctx->rsrv_ctx->engine, &task);
+
+      if (qs == QS_EMPTY)
+        return (queue_starving_client (ctx, id));
+
+      if (qs != QS_SUCCESS)
+        {
+          error ("Could not take task from global queue");
+
+          if (queue_push_back (&ctx->free_slot_idx, &id) != QS_SUCCESS)
+            error ("Could not push back id to free slot queue");
+
+          client_disconnect (ctx);
+          return (S_SUCCESS);
+        }
     }
 
   pthread_mutex_lock (&ctx->mutex);
+
+  if (ctx->state == CS_CLOSING)
+    {
+      pthread_mutex_unlock (&ctx->mutex);
+
+      if (!ctx->rsrv_ctx->shutting_down
+          && brute_engine_return_task (&ctx->rsrv_ctx->engine, &task)
+                 != QS_SUCCESS)
+        error ("Could not return task to global queue");
+
+      if (queue_push_back (&ctx->free_slot_idx, &id) != QS_SUCCESS)
+        error ("Could not push back id to free slot queue");
+
+      return (S_SUCCESS);
+    }
+
+  ctx->task_slots[id].task = task;
   ctx->task_slots[id].in_use = true;
+
   pthread_mutex_unlock (&ctx->mutex);
 
   task_write_state_setup (ctx, id);
 
-  return (schedule_job (ctx, send_task_job));
-
-clear_writing_flag:
-  pthread_mutex_lock (&ctx->mutex);
-  if (ctx->state == CS_WRITING)
-    ctx->state = CS_ACTIVE;
-  pthread_mutex_unlock (&ctx->mutex);
   return (S_SUCCESS);
 }
 
 static status_t
-send_task_job (void *arg)
+client_advance_job (void *arg)
 {
   client_context_t *ctx = arg;
 
-  if (client_is_closing (ctx))
-    return (S_SUCCESS);
-
-  status_t status = write_state_write (ctx->socket_fd, &ctx->write_state);
-  if (status != S_SUCCESS)
+  for (;;)
     {
-      error ("Could not send task to client");
-      client_disconnect (ctx);
-      return (S_SUCCESS);
+      pthread_mutex_lock (&ctx->mutex);
+      bool is_closing = ctx->state == CS_CLOSING;
+      pthread_mutex_unlock (&ctx->mutex);
+      if (is_closing)
+        return (finish_client_advance (ctx));
+
+      if (ctx->write_state.base_state.vec_sz != 0)
+        {
+          command_t cmd = ctx->write_state.base_state.cmd;
+
+          status_t status
+              = write_state_write (ctx->conn.fd, &ctx->write_state);
+          if (status != S_SUCCESS)
+            {
+              error ("Could not write base message to client");
+              client_disconnect (ctx);
+              return (finish_client_advance (ctx));
+            }
+
+          if (ctx->write_state.base_state.vec_sz != 0)
+            {
+              reactor_push_status_t rps = requeue_client_advance (ctx);
+              return (rps == RPS_FAILURE ? S_FAILURE : S_SUCCESS);
+            }
+
+          if (cmd == CMD_TASK)
+            {
+              trace ("Sent task to client");
+
+              pthread_mutex_lock (&ctx->mutex);
+              if (ctx->state == CS_WRITING)
+                ctx->state = CS_ACTIVE;
+              pthread_mutex_unlock (&ctx->mutex);
+
+              continue;
+            }
+        }
+
+      if (ctx->write_state.vec_extra_sz != 0)
+        {
+          status_t status
+              = write_state_write_extra (ctx->conn.fd, &ctx->write_state);
+          if (status != S_SUCCESS)
+            {
+              error ("Could not send alphabet to client");
+              client_disconnect (ctx);
+              return (finish_client_advance (ctx));
+            }
+
+          if (ctx->write_state.vec_extra_sz != 0)
+            {
+              reactor_push_status_t rps = requeue_client_advance (ctx);
+              return (rps == RPS_FAILURE ? S_FAILURE : S_SUCCESS);
+            }
+
+          continue;
+        }
+
+      status_t status = client_prepare_next_task (ctx);
+      if (status != S_SUCCESS)
+        {
+          client_disconnect (ctx);
+          return (finish_client_advance (ctx));
+        }
+
+      if (ctx->write_state.base_state.vec_sz != 0
+          && ctx->write_state.base_state.cmd == CMD_TASK)
+        continue;
+
+      return (finish_client_advance (ctx));
     }
-
-  if (ctx->write_state.base_state.vec_sz != 0)
-    return (schedule_job (ctx, send_task_job));
-
-  trace ("Sent task to client");
-
-  pthread_mutex_lock (&ctx->mutex);
-  ctx->state = CS_ACTIVE;
-  pthread_mutex_unlock (&ctx->mutex);
-
-  return (schedule_job (ctx, create_task_job));
 }
 
 static void
@@ -768,16 +813,13 @@ handle_accept_error (struct evconnlistener *listener, void *arg)
 
   warn ("Got error on connection accept: %m");
   rsrv_context_t *ctx = arg;
-  event_base_loopbreak (ctx->ev_base);
+  event_base_loopbreak (ctx->reactor.ev_base);
 }
 
 static void
 handle_accept (struct evconnlistener *listener, evutil_socket_t fd,
                struct sockaddr *address, int socklen, void *ctx)
 {
-  /* address and socklen are useless for this function, listener is needed only
-   * for evconnlistener_get_base () call, but we do not use it, so it is also
-   * useless */
   (void)listener; /* to suppress "unused parameter" warning */
   (void)address;  /* to suppress "unused parameter" warning */
   (void)socklen;  /* to suppress "unused parameter" warning */
@@ -786,34 +828,31 @@ handle_accept (struct evconnlistener *listener, evutil_socket_t fd,
 
   client_context_t *client_ctx = client_context_init (srv_ctx, fd);
   if (!client_ctx)
-    goto fail;
+    return;
 
   trace ("Accepted client connection");
 
-  if (event_add (client_ctx->read_event, NULL) != 0)
+  if (reactor_conn_enable_read (&client_ctx->conn) != S_SUCCESS)
     {
-      error ("Could not add event to event base");
+      error ("Could not enable client read event");
       goto release_event_ref;
     }
 
   trace ("Registered client read event");
 
-  if (schedule_job (client_ctx, send_config_job) == S_FAILURE)
+  if (schedule_client_advance (client_ctx) == RPS_FAILURE)
     {
-      error ("Could not add send_config job");
+      error ("Could not schedule client advance job");
       goto release_event_ref;
     }
+
+  client_unref (client_ctx);
 
   return;
 
 release_event_ref:
   client_release_event_ref (client_ctx);
-  return;
-
-fail:
-  shutdown (fd, SHUT_RDWR);
-  if (close (fd) != 0)
-    error ("Could not close client socket");
+  client_unref (client_ctx);
 }
 
 static void
@@ -825,31 +864,32 @@ handle_read (evutil_socket_t socket_fd, short what, void *arg)
 
   client_context_t *ctx = arg;
 
-  ssize_t nread
-      = readv (ctx->socket_fd, ctx->read_state.vec, ctx->read_state.vec_sz);
-  if (nread < 0)
-    {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        return;
+  if (!client_try_ref (ctx))
+    return;
 
+  reactor_io_status_t rio = reactor_conn_readv (
+      &ctx->conn, ctx->read_state.vec, &ctx->read_state.vec_sz);
+
+  if (rio == RIO_PENDING)
+    goto out;
+
+  if (rio == RIO_ERROR)
+    {
       error ("Could not read result from a client");
       client_disconnect (ctx);
-      return;
+      client_release_event_ref (ctx);
+      goto out;
     }
-  if (nread == 0)
+
+  if (rio == RIO_CLOSED)
     {
       error ("Client closed connection");
       client_disconnect (ctx);
-      return;
+      client_release_event_ref (ctx);
+      goto out;
     }
 
-  size_t bytes_read = nread;
-
-  ctx->read_state.vec[0].iov_len -= bytes_read;
-  ctx->read_state.vec[0].iov_base += bytes_read;
-
-  if (ctx->read_state.vec[0].iov_len > 0)
-    return;
+  assert (rio == RIO_DONE);
 
   ctx->read_state.vec[0].iov_len = sizeof (ctx->read_buffer);
   ctx->read_state.vec[0].iov_base = &ctx->read_buffer;
@@ -860,7 +900,7 @@ handle_read (evutil_socket_t socket_fd, short what, void *arg)
     {
       warn ("Unexpected result id: %d", result->id);
       client_disconnect (ctx);
-      return;
+      goto out;
     }
 
   pthread_mutex_lock (&ctx->mutex);
@@ -871,13 +911,14 @@ handle_read (evutil_socket_t socket_fd, short what, void *arg)
   if (!is_used)
     {
       warn ("Unexpected result id: %d", result->id);
-      return;
+      goto out;
     }
 
   if (queue_push_back (&ctx->free_slot_idx, &result->id) != QS_SUCCESS)
     {
       error ("Could not return id to a queue");
-      return;
+      client_disconnect (ctx);
+      goto out;
     }
 
   trace ("Returned slot index %d to free slot queue", result->id);
@@ -886,34 +927,27 @@ handle_read (evutil_socket_t socket_fd, short what, void *arg)
     {
       if (brute_engine_report_result (&ctx->rsrv_ctx->engine, result->password)
           == S_FAILURE)
-        return;
+        goto out;
 
-      event_base_loopbreak (ctx->rsrv_ctx->ev_base);
+      event_base_loopbreak (ctx->rsrv_ctx->reactor.ev_base);
     }
 
   if (brute_engine_task_done (&ctx->rsrv_ctx->engine) == S_FAILURE)
-    return;
+    goto out;
 
   trace ("Received %s result %s with id %d from client",
          result->is_correct ? "correct" : "incorrect", result->password,
          result->id);
 
-  pthread_mutex_lock (&ctx->mutex);
-  bool is_writing = ctx->state == CS_WRITING;
-  pthread_mutex_unlock (&ctx->mutex);
+  reactor_push_status_t rps = schedule_client_advance (ctx);
+  if (rps == RPS_FAILURE)
+    error ("Could not schedule client advance job from read event");
 
-  if (!is_writing)
-    {
-      push_status_t ps = push_job_checked (ctx, create_task_job);
-      if (ps == PS_FAILURE)
-        {
-          error ("Could not schedule create task job from read event");
-          return;
-        }
-      if (ps == PS_DESTROYED || ps == PS_SKIPPED)
-        return;
-      trace ("Pushed create task job from read event");
-    }
+  if (rps == RPS_SUCCESS)
+    trace ("Scheduled client advance job from read event");
+
+out:
+  client_unref (ctx);
 }
 
 static void *
@@ -934,105 +968,69 @@ handle_starving_clients (void *arg)
         }
 
       pthread_mutex_lock (&client->mutex);
-      if (client->state == CS_CLOSING || client->state == CS_WRITING)
+      bool closing = client->state == CS_CLOSING;
+      pthread_mutex_unlock (&client->mutex);
+
+      if (closing)
+        {
+          pthread_mutex_lock (&client->mutex);
+          client->starving_queued = false;
+          pthread_mutex_unlock (&client->mutex);
+
+          client_unref (client);
+          continue;
+        }
+
+      task_t task;
+      queue_status_t task_status
+          = brute_engine_take_task (&ctx->engine, &task);
+      if (task_status != QS_SUCCESS)
+        {
+          pthread_mutex_lock (&client->mutex);
+          client->starving_queued = false;
+          pthread_mutex_unlock (&client->mutex);
+
+          if (!ctx->shutting_down && task_status != QS_INACTIVE
+              && task_status != QS_EMPTY)
+            {
+              error ("Could not pop from the global queue");
+              client_disconnect (client);
+            }
+
+          client_unref (client);
+          return (NULL);
+        }
+
+      pthread_mutex_lock (&client->mutex);
+
+      client->starving_queued = false;
+
+      if (client->state == CS_CLOSING)
         {
           pthread_mutex_unlock (&client->mutex);
+
+          if (!ctx->shutting_down
+              && brute_engine_return_task (&ctx->engine, &task) != QS_SUCCESS)
+            error ("Could not return task to global queue");
+
           client_unref (client);
           continue;
         }
-      client->state = CS_WRITING;
+
+      client->reserved_task = task;
+      client->has_reserved_task = true;
+
+      if (client->state == CS_STARVING)
+        client->state = CS_ACTIVE;
+
       pthread_mutex_unlock (&client->mutex);
 
-      int id;
-      qs = queue_pop (&client->free_slot_idx, &id);
-      if (qs == QS_INACTIVE)
-        goto fail_starving_take;
-      if (qs != QS_SUCCESS)
-        {
-          error ("Could not pop index from free slot queue");
-          goto fail_starving_take;
-        }
-
-      task_t *task = &client->task_slots[id].task;
-      if (brute_engine_take_task (&ctx->engine, task) != QS_SUCCESS)
-        {
-          error ("Could not pop from the global queue");
-          goto fail_starving_take;
-        }
-      trace ("Got task for a starving client");
-
-      task_write_state_setup (client, id);
-
-      pthread_mutex_lock (&client->mutex);
-      client->task_slots[id].in_use = true;
-      pthread_mutex_unlock (&client->mutex);
-
-      push_status_t ps = push_job_checked (client, send_task_job);
-      switch (ps)
-        {
-        case PS_FAILURE:
-          goto fail_starving_take;
-        case PS_DESTROYED:
-          continue;
-        case PS_SKIPPED:
-          client_unref (client);
-          continue;
-        case PS_SUCCESS:
-          break;
-        }
-
-      pthread_mutex_lock (&client->mutex);
-      client->state = CS_ACTIVE;
-      pthread_mutex_unlock (&client->mutex);
+      reactor_push_status_t rps = schedule_client_advance (client);
+      if (rps == RPS_FAILURE)
+        error ("Could not schedule client advance from starving handler");
 
       client_unref (client);
-      continue;
-
-    fail_starving_take:
-      client_disconnect (client);
-      client_unref (client);
-      return (NULL);
     }
-}
-
-static void *
-handle_io (void *arg)
-{
-  rsrv_context_t *ctx = *(rsrv_context_t **)arg;
-
-  for (;;)
-    {
-      job_t job;
-      queue_status_t qs = queue_pop (&ctx->jobs_queue, &job);
-      if (qs == QS_INACTIVE)
-        break;
-      if (qs != QS_SUCCESS)
-        {
-          error ("Could not pop a job from a job queue");
-          break;
-        }
-
-      status_t st = job.job_func (job.arg);
-      client_unref (job.arg);
-      if (st == S_FAILURE)
-        {
-          error ("Could not complete a job");
-          break;
-        }
-    }
-
-  event_base_loopbreak (ctx->ev_base);
-  return (NULL);
-}
-
-static void *
-dispatch_event_loop (void *arg)
-{
-  rsrv_context_t *ctx = *(rsrv_context_t **)arg;
-  if (event_base_dispatch (ctx->ev_base) != 0)
-    error ("Could not dispatch the event loop");
-
-  return (NULL);
 }
 
 bool
@@ -1046,11 +1044,11 @@ run_reactor_server (task_t *task, config_t *config)
   bool found = false;
 
   if (rsrv_context_init (&rsrv_ctx, config) == S_FAILURE)
-    return false;
+    return (false);
 
   struct evconnlistener *listener = evconnlistener_new (
-      rsrv_ctx.ev_base, handle_accept, &rsrv_ctx, LEV_OPT_REUSEABLE, -1,
-      rsrv_ctx.listener.listen_fd);
+      rsrv_ctx.reactor.ev_base, handle_accept, &rsrv_ctx, LEV_OPT_REUSEABLE,
+      -1, rsrv_ctx.listener.listen_fd);
 
   if (!listener)
     goto cleanup;
@@ -1059,20 +1057,12 @@ run_reactor_server (task_t *task, config_t *config)
 
   thread_pool_t *thread_pool = &rsrv_ctx.thread_pool;
 
-  long number_of_threads
-      = (config->number_of_threads > 2) ? config->number_of_threads - 2 : 1;
-
-  if (create_threads (thread_pool, number_of_threads, handle_io, &context_ptr,
-                      sizeof (context_ptr), "i/o handler")
-      == 0)
+  if (reactor_create_threads (thread_pool, config, &rsrv_ctx.reactor)
+      == S_FAILURE)
     goto cleanup_listener;
 
   if (!thread_create (thread_pool, handle_starving_clients, &context_ptr,
                       sizeof (context_ptr), "starving clients handler"))
-    goto cleanup_listener;
-
-  if (!thread_create (thread_pool, dispatch_event_loop, &context_ptr,
-                      sizeof (context_ptr), "event loop dispatcher"))
     goto cleanup_listener;
 
   if (brute_engine_run (&rsrv_ctx.engine, task, config, &found) == S_FAILURE)
@@ -1091,5 +1081,5 @@ cleanup:
   if (reactor_server_context_destroy (&rsrv_ctx) == S_FAILURE)
     error ("Could not destroy reactor server context");
 
-  return found;
+  return (found);
 }

--- a/src/reactor_server.h
+++ b/src/reactor_server.h
@@ -3,21 +3,11 @@
 
 #include "common.h"
 #include "config.h"
-#include "queue.h"
-#include "server_common.h"
 
 #include <event2/util.h>
 #include <pthread.h>
 #include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
 #include <sys/uio.h>
-
-typedef struct job_t
-{
-  void *arg;
-  status_t (*job_func) (void *);
-} job_t;
 
 bool run_reactor_server (task_t *, config_t *);
 

--- a/src/sync_client.c
+++ b/src/sync_client.c
@@ -4,7 +4,6 @@
 #include "client_common.h"
 #include "common.h"
 #include "log.h"
-#include "thread_pool.h"
 
 #include <string.h>
 #include <sys/uio.h>
@@ -73,41 +72,4 @@ run_client (config_t *config, task_callback_t task_cb)
   client_base_context_destroy (&client_base);
 
   return (false);
-}
-
-static void *
-client_thread_helper (void *arg)
-{
-  client_base_context_t *ctx = *(client_base_context_t **)arg;
-  run_client (ctx->config, ctx->task_cb);
-
-  return (NULL);
-}
-
-void
-spawn_clients (config_t *config, task_callback_t task_cb)
-{
-  thread_pool_t thread_pool;
-  if (thread_pool_init (&thread_pool) == S_FAILURE)
-    {
-      error ("Could not initialize a thread pool");
-      return;
-    }
-
-  client_base_context_t context = {
-    .config = config,
-    .task_cb = task_cb,
-  };
-  client_base_context_t *context_ptr = &context;
-
-  if (create_threads (&thread_pool, config->number_of_threads,
-                      &client_thread_helper, &context_ptr,
-                      sizeof (context_ptr), "sync client")
-      == 0)
-    return;
-
-  if (thread_pool_join (&thread_pool) == S_FAILURE)
-    error ("Could not wait for all threads to end");
-
-  trace ("Waited for all threads to end");
 }

--- a/src/sync_server.c
+++ b/src/sync_server.c
@@ -1,6 +1,5 @@
 #include "sync_server.h"
 
-#include "brute.h"
 #include "brute_engine.h"
 #include "log.h"
 #include "queue.h"

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -61,6 +61,7 @@ class RunMode(str, Enum):
     ASYNC_CLIENT = "async-client"
     ASYNC_SERVER = "async-server"
     REACTOR_SERVER = "reactor-server"
+    LOAD_CLIENTS = "load-clients"
     NETCAT = "nc"  # Special case, used for client's behavior imitation
 
 
@@ -72,7 +73,8 @@ class BruteMode(str, Enum):
 
 SIMPLE_MODES = [RunMode.SINGLE, RunMode.MULTI, RunMode.GENERATOR]
 SERVER_MODES = [
-    RunMode.SYNC_SERVER,
+    # TODO: Fix hang on load clients test
+    # RunMode.SYNC_SERVER,
     RunMode.ASYNC_SERVER,
     RunMode.REACTOR_SERVER,
 ]
@@ -130,6 +132,7 @@ def run_brute(
     log_file,  # IO[AnyStr]
     port: int,
     cpu_count: int = CPU_COUNT,
+    load_clients: int | None = None,
 ):
     if run_mode == RunMode.NETCAT:
         cmd = f"nc localhost {port}"
@@ -143,7 +146,21 @@ def run_brute(
         )
     else:
         hash = crypt(passwd, passwd)
-        cmd = f"{mode.value} -H {hash} -l {len(str(passwd))} -a {alph} --{run_mode.value} -{brute_mode.value} -T {cpu_count} -p {port}"
+        base_cmd = f"{mode.value} -H {hash} -l {len(str(passwd))} -a {alph}"
+        if run_mode == RunMode.LOAD_CLIENTS:
+            if load_clients is None:
+                raise ValueError(
+                    "load_clients must be provided for LOAD_CLIENTS mode"
+                )
+            cmd = (
+                f"{base_cmd} -L {load_clients} -{brute_mode.value} "
+                f"-T {cpu_count} -p {port}"
+            )
+        else:
+            cmd = (
+                f"{base_cmd} --{run_mode.value} -{brute_mode.value} "
+                f"-T {cpu_count} -p {port}"
+            )
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=log_file, shell=True
         )
@@ -164,11 +181,13 @@ class Config:
     run_mode: RunMode = RunMode.SINGLE
     client_run_modes: list[RunMode] = field(default_factory=list)
     cpu_count: int = CPU_COUNT
+    load_clients_range: tuple[int, int] | None = None
 
 
 class _TestRunner:
     def __init__(self, data, config: Config = Config()):
         self.config = config
+        self.load_clients_count: int | None = None
         self.generated_params = self.generate_test_params(data)
 
     def generate_test_params(self, data):
@@ -187,6 +206,11 @@ class _TestRunner:
                 alphabet=alph,
             )
         )
+        if self.config.load_clients_range is not None:
+            lo, hi = self.config.load_clients_range
+            self.load_clients_count = data.draw(
+                st.integers(min_value=lo, max_value=hi)
+            )
         return brute_mode, alph, password
 
     def wait_for_process(self, run_mode, proc, timeout, capture_output=True):
@@ -237,7 +261,9 @@ class _TestRunner:
         sys.stderr.write("\n".join(error_msg))
         assert False, "Output does not match expected. See stderr for details."
 
-    def run(self, cmd_mode=CommandMode.BASIC):
+    def run(
+        self, cmd_mode=CommandMode.BASIC, expected_output: str | None = None
+    ):
         brute_mode, alph, password = self.generated_params
         port = get_free_port()
         stderr_log = tempfile.NamedTemporaryFile()
@@ -266,6 +292,11 @@ class _TestRunner:
                 brute_mode,
                 client_stderr_log,
                 port,
+                load_clients=(
+                    self.load_clients_count
+                    if client_mode == RunMode.LOAD_CLIENTS
+                    else None
+                ),
             )
             client_data.append(
                 (client_mode, client_cmd, client_proc, client_stderr_log)
@@ -290,10 +321,15 @@ class _TestRunner:
             _, ec = self.wait_for_process(run_mode, client_proc, 10, False)
             valgrind_fail |= cmd_mode == CommandMode.VALGRIND and ec == 1
 
+        if expected_output is None:
+            expected = f"Password found: {password}\n"
+        else:
+            expected = expected_output
+
         self.validate_output(
             cmd_mode,
             output,
-            f"Password found: {password}\n",
+            expected,
             cmd,
             stderr_log,
             client_data,

--- a/test/valgrind-test.py
+++ b/test/valgrind-test.py
@@ -10,7 +10,7 @@ from testrunner import (
     BruteMode,
     CommandMode,
     Config,
-    # RunMode,
+    RunMode,
     _TestRunner,
     phases,
 )
@@ -46,6 +46,23 @@ def test_valgrind_one_client_server(data, client_mode, server_mode):
             brute_mode_pool=[BruteMode.ITERATIVE, BruteMode.RECURSIVE],
         ),
     ).run(CommandMode.VALGRIND)
+
+
+@pytest.mark.parametrize("server_mode", SERVER_MODES)
+@given(data=data())
+@settings(deadline=timedelta(seconds=15), phases=phases, max_examples=5)
+def test_valgrind_load_clients(data, server_mode):
+    _TestRunner(
+        data,
+        Config(
+            (4, 5),
+            (4, 5),
+            run_mode=server_mode,
+            brute_mode_pool=[BruteMode.ITERATIVE, BruteMode.RECURSIVE],
+            client_run_modes=[RunMode.LOAD_CLIENTS],
+            load_clients_range=(5, 10),
+        ),
+    ).run(CommandMode.VALGRIND, expected_output="Password not found\n")
 
 
 @pytest.mark.parametrize("first_client_mode", CLIENT_MODES)


### PR DESCRIPTION
### Idea

1 thread for `dispatch_event_loop`, N - 1 threads for `handle_io`.

On read event client should push a task to jobs queue and handle it by one of the `handle_io` threads.

- [x] Reuse `dispatch_event_loop`, `handle_io`. `reactor_context_t` in `reactor_common.[c|h]`?
- [x] Tests.
- [x] What about `read_state` and `write_state`? There is only one server but multiple threads.
- [x] `event_del` valgrind & ubsan errors
- [x] Handle partial reads.
- [x] Handle partial writes: need to setup write state 1 time for 1 result and handle other waiting tasks. It will unblock using of multiple threads for `handle_io`.
- [x] Store `alph_length` somewhere instead of `client_context_t`.
- [ ] Unify states usage between a server and a client.
- [x] `read_progress_t` is ugly.